### PR TITLE
Update module name to make it installable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module mobius-hotline-client
+module github.com/jhalter/mobius-hotline-client
 
 go 1.22
 

--- a/main.go
+++ b/main.go
@@ -3,14 +3,15 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/jhalter/mobius/hotline"
-	"github.com/rivo/tview"
 	"log/slog"
-	"mobius-hotline-client/ui"
 	"os"
 	"os/signal"
 	"runtime"
 	"syscall"
+
+	"github.com/jhalter/mobius-hotline-client/ui"
+	"github.com/jhalter/mobius/hotline"
+	"github.com/rivo/tview"
 )
 
 var logLevels = map[string]slog.Level{


### PR DESCRIPTION
When attempting to install mobius-hotline-client I get this:

```
$ go install github.com/jhalter/mobius-hotline-client@v0.1.0
go: downloading github.com/jhalter/mobius-hotline-client v0.1.0
go: github.com/jhalter/mobius-hotline-client@v0.1.0: version constraints conflict:
	github.com/jhalter/mobius-hotline-client@v0.1.0: parsing go.mod:
	module declares its path as: mobius-hotline-client
	        but was required as: github.com/jhalter/mobius-hotline-client
```

Updated the module name to fix this